### PR TITLE
Add document signing step

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ NEXT_PUBLIC_STRIPE_KEY=<your-stripe-public-key>
 
 You'll also need to setup the integrations in your Medusa server. See the [Medusa documentation](https://docs.medusajs.com) for more information on how to configure [Stripe](https://docs.medusajs.com/resources/commerce-modules/payment/payment-provider/stripe#main).
 
+## Document signing
+
+If you want customers to sign a document after successful payment, provide the URL to your DocuSign or PandaDoc embed page in the following environment variable:
+
+```shell
+NEXT_PUBLIC_SIGN_DOCUMENT_URL=<your-signature-iframe-url>
+```
+
 # Resources
 
 ## Learn more about Medusa

--- a/src/app/[countryCode]/(main)/order/[id]/sign/page.tsx
+++ b/src/app/[countryCode]/(main)/order/[id]/sign/page.tsx
@@ -1,0 +1,50 @@
+import { retrieveOrder } from "@lib/data/orders"
+import LocalizedClientLink from "@modules/common/components/localized-client-link"
+import { Heading, Text } from "@medusajs/ui"
+import { Metadata } from "next"
+import { notFound } from "next/navigation"
+
+export const metadata: Metadata = {
+  title: "Sign Document",
+}
+
+export default async function OrderSignPage({
+  params,
+}: {
+  params: { id: string }
+}) {
+  const { id } = params
+  const order = await retrieveOrder(id).catch(() => null)
+
+  if (!order) {
+    return notFound()
+  }
+
+  const signUrl =
+    process.env.NEXT_PUBLIC_SIGN_DOCUMENT_URL ||
+    "https://example.com/sign-document"
+
+  return (
+    <div className="flex flex-col gap-y-4 items-center w-full mx-auto mt-10 mb-20">
+      <Heading level="h1" className="text-xl text-zinc-900">
+        Sign your document
+      </Heading>
+      <Text className="text-zinc-600 text-center max-w-xl">
+        Please review and sign the document below to complete your purchase.
+      </Text>
+      <div className="w-full max-w-2xl h-[600px]">
+        <iframe
+          src={signUrl}
+          className="w-full h-full border rounded-md"
+          title="Document Signature"
+        />
+      </div>
+      <LocalizedClientLink
+        href={`/order/${order.id}/confirmed`}
+        className="text-ui-fg-interactive hover:text-ui-fg-interactive-hover underline mt-4"
+      >
+        Continue to order confirmation
+      </LocalizedClientLink>
+    </div>
+  )
+}

--- a/src/lib/data/cart.ts
+++ b/src/lib/data/cart.ts
@@ -416,7 +416,7 @@ export async function placeOrder(cartId?: string) {
     revalidateTag(orderCacheTag)
 
     removeCartId()
-    redirect(`/${countryCode}/order/${cartRes?.order.id}/confirmed`)
+    redirect(`/${countryCode}/order/${cartRes?.order.id}/sign`)
   }
 
   return cartRes.cart


### PR DESCRIPTION
## Summary
- introduce optional document signing URL in README
- redirect to an order `sign` route after placing an order
- add new `/order/[id]/sign` page with an embedded iFrame for Docusign or PandaDoc

## Testing
- `yarn lint` *(fails: network access required)*
- `yarn build` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_686ff203caf88321b2940132b0cdc728