### PR TITLE
Add Zoho payment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,13 @@ Your site is now running at http://localhost:8000!
 By default this starter supports the following payment integrations
 
 - [Stripe](https://stripe.com/)
+- [Zoho](https://www.zoho.com/)
 
 To enable the integrations you need to add the following to your `.env.local` file:
 
 ```shell
 NEXT_PUBLIC_STRIPE_KEY=<your-stripe-public-key>
+NEXT_PUBLIC_ZOHO_KEY=<your-zoho-api-key>
 ```
 
 You'll also need to setup the integrations in your Medusa server. See the [Medusa documentation](https://docs.medusajs.com) for more information on how to configure [Stripe](https://docs.medusajs.com/resources/commerce-modules/payment/payment-provider/stripe#main).

--- a/src/lib/constants.tsx
+++ b/src/lib/constants.tsx
@@ -4,6 +4,7 @@ import { CreditCard } from "@medusajs/icons"
 import Ideal from "@modules/common/icons/ideal"
 import Bancontact from "@modules/common/icons/bancontact"
 import PayPal from "@modules/common/icons/paypal"
+import Zoho from "@modules/common/icons/zoho"
 
 /* Map of payment provider_id to their title and icon. Add in any payment providers you want to use. */
 export const paymentInfoMap: Record<
@@ -26,6 +27,10 @@ export const paymentInfoMap: Record<
     title: "PayPal",
     icon: <PayPal />,
   },
+  pp_zoho_zoho: {
+    title: "Zoho Payment",
+    icon: <Zoho />,
+  },
   pp_system_default: {
     title: "Manual Payment",
     icon: <CreditCard />,
@@ -42,6 +47,9 @@ export const isPaypal = (providerId?: string) => {
 }
 export const isManual = (providerId?: string) => {
   return providerId?.startsWith("pp_system_default")
+}
+export const isZoho = (providerId?: string) => {
+  return providerId?.startsWith("pp_zoho")
 }
 
 // Add currencies that don't need to be divided by 100

--- a/src/modules/checkout/components/payment-button/index.tsx
+++ b/src/modules/checkout/components/payment-button/index.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { isManual, isStripe } from "@lib/constants"
+import { isManual, isStripe, isZoho } from "@lib/constants"
 import { placeOrder } from "@lib/data/cart"
 import { HttpTypes } from "@medusajs/types"
 import { Button } from "@medusajs/ui"
@@ -39,6 +39,8 @@ const PaymentButton: React.FC<PaymentButtonProps> = ({
       return (
         <ManualTestPaymentButton notReady={notReady} data-testid={dataTestId} />
       )
+    case isZoho(paymentSession?.provider_id):
+      return <ZohoPaymentButton notReady={notReady} data-testid={dataTestId} />
     default:
       return <Button disabled>Select a payment method</Button>
   }
@@ -185,6 +187,45 @@ const ManualTestPaymentButton = ({ notReady }: { notReady: boolean }) => {
       <ErrorMessage
         error={errorMessage}
         data-testid="manual-payment-error-message"
+      />
+    </>
+  )
+}
+
+const ZohoPaymentButton = ({ notReady }: { notReady: boolean }) => {
+  const [submitting, setSubmitting] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const onPaymentCompleted = async () => {
+    await placeOrder()
+      .catch((err) => {
+        setErrorMessage(err.message)
+      })
+      .finally(() => {
+        setSubmitting(false)
+      })
+  }
+
+  const handlePayment = () => {
+    setSubmitting(true)
+
+    onPaymentCompleted()
+  }
+
+  return (
+    <>
+      <Button
+        disabled={notReady}
+        isLoading={submitting}
+        onClick={handlePayment}
+        size="large"
+        data-testid="zoho-payment-button"
+      >
+        Place order
+      </Button>
+      <ErrorMessage
+        error={errorMessage}
+        data-testid="zoho-payment-error-message"
       />
     </>
   )

--- a/src/modules/common/icons/zoho.tsx
+++ b/src/modules/common/icons/zoho.tsx
@@ -1,0 +1,30 @@
+import React from "react"
+
+import { IconProps } from "types/icon"
+
+const Zoho: React.FC<IconProps> = ({
+  size = "20",
+  color = "currentColor",
+  ...attributes
+}) => {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...attributes}
+    >
+      <path
+        d="M4 5H20L4 19H20"
+        stroke={color}
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+export default Zoho


### PR DESCRIPTION
## Summary
- add Zoho icon
- support Zoho provider in payment mapping and helper
- handle Zoho in checkout payment button
- document Zoho integration

## Testing
- `yarn lint` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_686ff1c4016c8321afc83be851aec270